### PR TITLE
fix for mementos containing (non-animated) GIFs posting to Twitter

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = u'Shawn M. Jones'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'0.2019.07.11.031608'
+release = u'0.2019.07.11.140435'
 
 
 # -- General configuration ---------------------------------------------------

--- a/raintale/version.py
+++ b/raintale/version.py
@@ -1,3 +1,3 @@
 __appname__ = "raintale"
-__appversion__ = '0.2019.07.11.031608'
+__appversion__ = '0.2019.07.11.140435'
 __useragent__ = "{}/{}".format(__appname__, __appversion__)


### PR DESCRIPTION
While testing with http://arquivo.pt/wayback/19980205082901/http://www.caleida.pt/saramago/ I discovered that not only does Twitter not allow multiple animated GIFs per post, it does not allow multiple GIFs per post. This code converts GIFs to PNGs before posting to Twitter.