### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ Raintale uses ```pip``` for build and installation. Clone this repository and ty
 
 to build and install the version from the source code on your machine.
 
-# The future of Raintale
+# The future of raintale
 
 We are working on additional storytellers and presets. Storytellers must be either a file format or an online service that supports an API. The choice in storyteller is highly dependent upon the capabilities and terms of that online service's API.


### PR DESCRIPTION
This PR remedies a triviality in the README, but makes it slightly more consistent.

Regarding capitalization, the project's name appears to be un-capitalized, though it happens to occur at the beginning of the sentence a few times. This is fine, albeit syntactically ambiguous (should all lowercase brands always be lowercase?), but the final header capitalizes Raintale in `The future of Raintale` (cf. `Building raintale`). The preceding header is all lowercase.

This PR simply makes the final header consistent with the instances of the name throughout the README.